### PR TITLE
Github Pull Requests doc - missing a crucial step in 'before you begin'

### DIFF
--- a/source/_docs/guides/github-pull-requests.md
+++ b/source/_docs/guides/github-pull-requests.md
@@ -79,6 +79,7 @@ Generally, use of Composer is optional; however, some Drupal modules, such as th
 
     <br>
 2.  Generate a [machine token](/docs/machine-tokens/) and [log in with Terminus](/docs/terminus/install/#authenticate).
+3.  [Authorize CircleCI on Github](https://github.com/login/oauth/authorize?client_id=78a2ba87f071c28e65bb)
 
 ## Set Up a New Project
 


### PR DESCRIPTION
Adding "Authorize CircleCI on Github" to the "Before you begin" section.
Without this step, CircleCI tests will always fail.

Closes #

## Effect
PR includes the following changes:
-
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed
